### PR TITLE
Initialize TypeScript extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ VS Codeの `settings.json` でデフォルト文字コードを指定できま�
 
 ---
 
+## コマンドとデフォルト設定
+
+| コマンド | 説明 |
+| --- | --- |
+| **Grep: Set Search Encoding** | 検索に使用する文字コードを設定 |
+
+デフォルト設定は `grepEncodingSearch.defaultEncoding` で `"UTF-8"` が使われます。
+
+---
+
 ## サポートしている文字コード
 
 * UTF-8

--- a/package.json
+++ b/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "vscode-grep-encoding-search",
+  "displayName": "Grep Encoding Search",
+  "description": "Search using specified encoding from VS Code sidebar.",
+  "version": "0.0.1",
+  "publisher": "yourusername",
+  "engines": {
+    "vscode": "^1.70.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onCommand:grepEncodingSearch.setSearchEncoding"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "grepEncodingSearch.setSearchEncoding",
+        "title": "Grep: Set Search Encoding"
+      }
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Grep Encoding Search",
+      "properties": {
+        "grepEncodingSearch.defaultEncoding": {
+          "type": "string",
+          "default": "UTF-8",
+          "description": "Default encoding used for grep search"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "pretest": "npm run compile",
+    "test": "echo \"No tests\""
+  },
+  "devDependencies": {
+    "@types/node": "^16.11.7",
+    "@types/vscode": "^1.75.0",
+    "typescript": "^4.8.4"
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,24 @@
+import * as vscode from 'vscode';
+
+export function activate(context: vscode.ExtensionContext) {
+  const disposable = vscode.commands.registerCommand(
+    'grepEncodingSearch.setSearchEncoding',
+    async () => {
+      const config = vscode.workspace.getConfiguration('grepEncodingSearch');
+      const encoding = await vscode.window.showInputBox({
+        placeHolder: 'e.g. Shift_JIS, EUC-JP, UTF-8',
+        prompt: 'Enter encoding for search',
+        value: config.get<string>('defaultEncoding', 'UTF-8'),
+      });
+
+      if (encoding) {
+        await config.update('defaultEncoding', encoding, vscode.ConfigurationTarget.Workspace);
+        vscode.window.showInformationMessage(`Search encoding set to ${encoding}`);
+      }
+    }
+  );
+
+  context.subscriptions.push(disposable);
+}
+
+export function deactivate() {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "lib": ["es6"],
+    "outDir": "out",
+    "rootDir": "src",
+    "sourceMap": true,
+    "strict": true
+  },
+  "exclude": ["node_modules", ".vscode-test"]
+}


### PR DESCRIPTION
## Summary
- add TypeScript-based VSCode extension scaffolding
- implement `Grep: Set Search Encoding` command
- store encoding in workspace settings
- document available command and default configuration

## Testing
- `npm test` *(fails: Cannot find module 'vscode')*

------
https://chatgpt.com/codex/tasks/task_b_683d2087cbcc83209f4bc0f823de5207